### PR TITLE
Feature: Add funcionality for favourite ride routes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -431,7 +431,6 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.0.6.tgz",
       "integrity": "sha512-5Gw8mXtKXvcvDMWEciPLRYB6Ja5vsikLAidZsdCEIF6Bc51GmoqT5Tk/Ke+ciCd5Hq9Aco/IcHxT1RC3470lZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -483,7 +482,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.0.5.tgz",
       "integrity": "sha512-/ZI11F6Wxr8TZRVO4O7pmhBJ9YxDg9mvA76e0PiivmqZggM02HY0y3XPMP3hAOe4K+PfaVBgMAu3P9t32klzfA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -500,7 +498,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.0.5.tgz",
       "integrity": "sha512-92sv9pVm9o/8KfPM7T8j5VQmTaSOqmIajrJF8evXE2dNJcwkBpVtzZUqDzr23AV3vg94C7eYU64i8qrsmJ+cYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -514,7 +511,6 @@
       "integrity": "sha512-45sFKqt+badXl6Ab2XsxuOsdi0BbIZgcc9TdwmFPdXMNfcSUYDcPiOA0l1iPwDIZiu4VyqzepMfnHB9IwCatgA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.4",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -547,7 +543,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.0.5.tgz",
       "integrity": "sha512-HFXfO5YsBVM+IEaU8h3DZSxO98yDZM2v49NlSVNDzFD3fhnkpTmcgT2NKz9ulIiuV9N376itt+x+NG12sg/+Fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -573,7 +568,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.0.5.tgz",
       "integrity": "sha512-RcmXs/LgKyc7D70xVT+3aK/H2SCFEyuebAiw72Iz1te1Gbql2GDFF6hgEOaNwOUglDg8ogN5MdVif2DbRLD3Hw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -610,7 +604,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.0.5.tgz",
       "integrity": "sha512-UVCrqOxFmX6kAG3Y6jqjCWvLoTP7fxeY96AsxTMp1fkBdqbQbEPleWQpwngNimsuUPvf+rA6XOxsqiDmRex5mA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -744,7 +737,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1095,7 +1087,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1139,7 +1130,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1856,7 +1846,6 @@
       "integrity": "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.0",
         "@inquirer/confirm": "^5.1.19",
@@ -3954,8 +3943,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
@@ -4478,7 +4466,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4644,7 +4631,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -5343,7 +5329,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6051,7 +6036,6 @@
       "integrity": "sha512-GtldT42B8+jefDUC4yUKAvsaOrH7PDHmZxZXNgF2xMmymjUbRYJvpAybZAKEmXDGTM0mCsz8duOa4vTm5AY2Kg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -6169,7 +6153,6 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -7651,7 +7634,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -8284,8 +8266,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "4.0.0",
@@ -8323,7 +8304,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8446,7 +8426,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -9006,7 +8985,6 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",
@@ -9444,7 +9422,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/controllers/rides/FavouriteController.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/controllers/rides/FavouriteController.java
@@ -1,0 +1,32 @@
+package rs.ac.uns.ftn.asd.ProjekatSIIT2025.controllers.rides;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.dto.rides.FavouriteRideDTO;
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.services.FavouriteService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/favourites")
+public class FavouriteController {
+
+    @Autowired
+    FavouriteService favouriteService;
+
+    @PostMapping("/{rideId}")
+    public void addToFavourites(@PathVariable Long rideId, Authentication auth) {
+        favouriteService.addToFavourites(rideId, auth.getName());
+    }
+
+    @DeleteMapping("/{rideId}")
+    public void removeFromFavourites(@PathVariable Long rideId, Authentication auth) {
+        favouriteService.removeFromFavourites(rideId, auth.getName());
+    }
+
+    @GetMapping
+    public List<FavouriteRideDTO> getFavourites(Authentication auth) {
+        return favouriteService.getFavourites(auth.getName());
+    }
+}

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/dto/rides/FavouriteRideDTO.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/dto/rides/FavouriteRideDTO.java
@@ -1,0 +1,42 @@
+package rs.ac.uns.ftn.asd.ProjekatSIIT2025.dto.rides;
+
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.model.RideStop;
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.model.VehicleType;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class FavouriteRideDTO {
+    private Long id;
+    private List<RideStopDTO> locations;
+
+    public FavouriteRideDTO(Long id, List<RideStop> stops){
+        this.id = id;
+        this.locations = stops.stream()
+                .sorted(Comparator.comparingInt(RideStop::getOrderIndex))
+                .map(s -> new RideStopDTO(
+                        s.getLatitude(),
+                        s.getLongitude(),
+                        s.getAddress()
+                ))
+                .toList();
+    }
+
+    public FavouriteRideDTO() {}
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public List<RideStopDTO> getLocations() {
+        return locations;
+    }
+
+    public void setLocations(List<RideStopDTO> locations) {
+        this.locations = locations;
+    }
+}

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/dto/rides/RideStopDTO.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/dto/rides/RideStopDTO.java
@@ -5,6 +5,14 @@ public class RideStopDTO {
     private double lat;
     private double lng;
 
+    public RideStopDTO(double latitude, double longitude, String address) {
+        this.address = address;
+        this.lat = latitude;
+        this.lng = longitude;
+    }
+
+    public RideStopDTO() {}
+
     public double getLng() {
         return lng;
     }

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/model/Passenger.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/model/Passenger.java
@@ -32,11 +32,11 @@ public class Passenger extends User {
         this.rides = rides;
     }
 
-    public List<Ride> getFavouritePaths() {
+    public List<Ride> getFavouriteRides() {
         return favouriteRides;
     }
 
-    public void setFavouritePaths(List<Ride> favouritePaths) {
+    public void setFavouriteRides(List<Ride> favouritePaths) {
         this.favouriteRides = favouritePaths;
     }
 }

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/services/FavouriteService.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/services/FavouriteService.java
@@ -1,0 +1,63 @@
+package rs.ac.uns.ftn.asd.ProjekatSIIT2025.services;
+
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.dto.rides.FavouriteRideDTO;
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.model.Passenger;
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.model.Ride;
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.repositories.PassengerRepository;
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.repositories.RideRepository;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class FavouriteService {
+    @Autowired
+    PassengerRepository passengerRepository;
+
+    @Autowired
+    RideRepository rideRepository;
+
+    public void addToFavourites(Long rideId, String email) {
+        Passenger p = passengerRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Passenger not found: " + email));
+
+        Ride ride = rideRepository.findById(rideId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Ride not found"));
+
+        if (!p.getFavouriteRides().contains(ride)) {
+            p.getFavouriteRides().add(ride);
+            passengerRepository.save(p);
+        }
+    }
+
+    public void removeFromFavourites(Long rideId, String email) {
+        Passenger p = passengerRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Passenger not found: " + email));
+
+        p.getFavouriteRides()
+                .removeIf(r -> r.getId().equals(rideId));
+
+        passengerRepository.save(p);
+    }
+
+    public List<FavouriteRideDTO> getFavourites(String email) {
+        Passenger p = passengerRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Passenger not found: " + email));
+
+        return p.getFavouriteRides().stream()
+                .map(r -> new FavouriteRideDTO(
+                        r.getId(),
+                        r.getStops()
+                ))
+                .toList();
+    }
+}


### PR DESCRIPTION
Implemented functionality for favourite ride routes:

- Added API endpoints to add a ride to favourites, remove from favourites, and fetch all favourites for a passenger.
- FavouriteRideDTO created to return ride stops for the frontend.
- Ensured order of ride stops is preserved for proper display in the UI.
- Handled LazyInitializationException by fetching collections within transactional context.
- Updated Passenger entity to manage favourite rides.
- Frontend can now display favourite routes and pre-fill ride creation form from selected favourites.

This allows passengers to quickly select previously used routes when creating a new ride.

Closes #68 