### PR TITLE
Feature :  Rest integration tests for ride stopping implemented

### DIFF
--- a/server/ProjekatSIIT2025/pom.xml
+++ b/server/ProjekatSIIT2025/pom.xml
@@ -2,12 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.1</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.2</version>
+        <relativePath/>
+    </parent>
 	<groupId>rs.ac.uns.ftn.asd</groupId>
 	<artifactId>ProjekatSIIT2025</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
@@ -26,17 +26,13 @@
 		<tag/>
 		<url/>
 	</scm>
-	<properties>
-		<java.version>17</java.version>
-	</properties>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-websocket</artifactId>
 		</dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -47,16 +43,20 @@
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-websocket-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/config/SecurityConfig.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -22,6 +23,7 @@ import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true) //enables preAuthorize in controller methods!!
 public class SecurityConfig {
 
     @Autowired
@@ -36,7 +38,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain (HttpSecurity http){
+    public SecurityFilterChain securityFilterChain (HttpSecurity http) throws Exception {
         //disables csrf checks because jwt does it
         return http.csrf(customizer -> customizer.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
@@ -44,10 +46,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(request -> request
                     .requestMatchers("/api/v1/auth/register", "/api/v1/auth/login",
                             "/api/v1/forgot-password/**","/api/v1/auth/activate","/api/v1/users/image/**", "/api/v1/reviews/**" ,"/api/v1/auth/activate-driver",
-                            "/api/v1/rides/**", "/error", "/api/v1/rides/{id}/location", "/api/v1/rides/{id}/inconsistency-report",
+                             "/error", "/api/v1/rides/{id}/location", "/api/v1/rides/{id}/inconsistency-report",
                             "/error", "/api/v1/vehicles", "/api/v1/drivers/{id}/ride",
                             "/api/v1/forgot-password/**","/api/v1/auth/activate","/api/v1/auth/activate-driver",
-                            "/api/v1/rides/**",
                             "/api/v1/vehicles/active")
               .permitAll()
                     .anyRequest().authenticated()
@@ -62,14 +63,22 @@ public class SecurityConfig {
         //enables default login form
         //.formLogin(Customizer.withDefaults())
     }
-    @Bean
+    /*@Bean
     public AuthenticationProvider authenticationProvider(){
         //using customized user details service, not a default one
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider(userDetailsService);
         //provider.setPasswordEncoder(new BCryptPasswordEncoder(12));
         provider.setPasswordEncoder(passwordEncoder());
+        return provider;*/
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
         return provider;
     }
+
+
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception{
         return configuration.getAuthenticationManager();

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/controllers/auth/ForgotPasswordController.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/controllers/auth/ForgotPasswordController.java
@@ -70,20 +70,15 @@ public class ForgotPasswordController {
             user = userService.loadUserByUsername(request.getEmail());
         }
         catch(UsernameNotFoundException ex){
-            //return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Email does not exists.");
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Email not found!");
         }
         ForgotPassword forgotPassword = forgotPasswordService.findByOtpAndUser(request.getOtp(), (User) user);
         if(forgotPassword == null){
-            //System.out.println("ne postoji forgotPassword");
-            //return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid OTP");
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid OTP");
         }
-        //System.out.println(forgotPassword.getOtp());
         //check if otp expired
         if (forgotPassword.getExpirationTime().before(Date.from(Instant.now()))) {
             forgotPasswordService.deleteById(forgotPassword.getForgotPasswordId());
-            //return new ResponseEntity<>("OTP has expired", HttpStatus.EXPECTATION_FAILED);
             throw new ResponseStatusException(HttpStatus.EXPECTATION_FAILED, "OTP has expired");
         }
         return ResponseEntity.ok("OTP verified!");

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/controllers/rides/RideController.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/controllers/rides/RideController.java
@@ -83,7 +83,7 @@ public class RideController {
     }
     @PreAuthorize("hasRole('DRIVER')")
     @PutMapping("/stop-ride")
-    public ResponseEntity<String> panic(@RequestBody StopRideDTO request){
+    public ResponseEntity<String> stopRide(@RequestBody StopRideDTO request){
         rideService.stopRide(request);
         return ResponseEntity.ok("Ride stopped!");
     }

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/model/User.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/model/User.java
@@ -166,6 +166,7 @@ public class User implements UserDetails {
     @Override public boolean isAccountNonExpired() { return true; }
     @Override public boolean isAccountNonLocked() { return true; }
     @Override public boolean isCredentialsNonExpired() { return true; }
+    //if user activated his profile with email activation link then he becomes enabled
     @Override public boolean isEnabled() { return enabled; }
 
 }

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/services/AuthService.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/services/AuthService.java
@@ -79,7 +79,7 @@ public class AuthService {
         user.setPassword(encoder.encode(user.getPassword()));
         user.setRole(UserRole.valueOf("PASSENGER"));
         user.setBlocked(false);
-        user.setEnabled(false);
+        user.setEnabled(false); //user becomes enabled when he activates his profile from activation link
         user = userRepository.save(user);
 
         //handle profile picture upload

--- a/server/ProjekatSIIT2025/src/main/resources/application.properties
+++ b/server/ProjekatSIIT2025/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.datasource.username=postgres
 spring.datasource.password=totallySpies
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 #Hibernate kreira tabele na osnovu anotacija @Entity i kada aplikacija zavrsi sa radom dropuje ih (create-drop)
-spring.jpa.hibernate.ddl-auto = update
+spring.jpa.hibernate.ddl-auto = create-drop
 #hibernate SQL upiti se ispisuju na IDE konzoli
 spring.jpa.show-sql = false
 #formatira ispis SQL upita koje Hibernate pravi ka bazi na IDE konzoli

--- a/server/ProjekatSIIT2025/src/test/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/controllers/RideControllerTest.java
+++ b/server/ProjekatSIIT2025/src/test/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/controllers/RideControllerTest.java
@@ -1,0 +1,170 @@
+package rs.ac.uns.ftn.asd.ProjekatSIIT2025.controllers;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.dto.rides.StopRideDTO;
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.model.RideStop;
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.services.RideService;
+import java.time.LocalDateTime;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class RideControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RideService rideService;
+
+    private ObjectMapper om;
+
+    @BeforeEach
+    void setup() {
+        om = new ObjectMapper();
+        om.registerModule(new JavaTimeModule());
+    }
+
+    private StopRideDTO validDto() {
+        RideStop newDestination = new RideStop(
+                1L,
+                "Trg slobode 1, Novi Sad",
+                45.2551,
+                19.8452,
+                1,
+                null
+        );
+
+        return new StopRideDTO(
+                1L,
+                LocalDateTime.of(2026, 2, 5, 12, 30),
+                950.0,
+                newDestination
+        );
+    }
+    @Test
+    @DisplayName("DRIVER stops ride -> 200")
+    @WithMockUser(username = "driver@mail.com", roles = "DRIVER")
+    void stopRide_driver_ok() throws Exception {
+        doNothing().when(rideService).stopRide(ArgumentMatchers.any(StopRideDTO.class));
+        mockMvc.perform(
+                        put("/api/v1/rides/stop-ride")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                //transform java to json and send as http request body
+                                .content(om.writeValueAsString(validDto()))
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().string("Ride stopped!"));
+
+        //checks if the service is called in controller
+        verify(rideService).stopRide(ArgumentMatchers.any(StopRideDTO.class));
+    }
+    @Test
+    @DisplayName("Security test: unauthorized user stops the ride -> 401")
+    void stopRide_unauthorizedUser_should_be_rejected() throws Exception{
+        mockMvc.perform(
+                put("/api/v1/rides/stop-ride")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(om.writeValueAsString(validDto()))
+                )
+                .andExpect(status().is4xxClientError());
+    }
+    @Test
+    @DisplayName("Security test: passenger stops the ride -> 403")
+    @WithMockUser(username = "passenger@mail.com", roles = "PASSENGER")
+    void stopRide_notDriver_forbidden() throws Exception {
+        mockMvc.perform(
+                        put("/api/v1/rides/stop-ride")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(om.writeValueAsString(validDto()))
+                )
+                .andExpect(status().isForbidden());
+    }
+    @Test
+    @DisplayName("Exception: Ride not found -> 404")
+    @WithMockUser(username = "driver@mail.com", roles = "DRIVER")
+    void stopRide_rideNotFound_notFound() throws Exception {
+        doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Ride not found!"))
+                .when(rideService).stopRide(ArgumentMatchers.any(StopRideDTO.class));
+        mockMvc.perform(
+                        put("/api/v1/rides/stop-ride")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(om.writeValueAsString(validDto()))
+                )
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Exception: User not found -> 404")
+    @WithMockUser(username = "driver@mail.com", roles = "DRIVER")
+    void stopRide_userNotFound_notFound() throws Exception {
+        doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found!"))
+                .when(rideService).stopRide(ArgumentMatchers.any(StopRideDTO.class));
+        mockMvc.perform(
+                        put("/api/v1/rides/stop-ride")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(om.writeValueAsString(validDto()))
+                )
+                .andExpect(status().isNotFound());
+    }
+    @Test
+    @DisplayName("Exception: End time null -> 400")
+    @WithMockUser(username = "driver@mail.com", roles = "DRIVER")
+    void stopRide_endTimeNull_400() throws Exception {
+        doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "End time can not be null!"))
+                .when(rideService).stopRide(ArgumentMatchers.any(StopRideDTO.class));
+        StopRideDTO dto = new StopRideDTO(
+                1L,
+                null, // null end time
+                950.0,
+                new RideStop(1L, "Trg slobode 1, Novi Sad", 45.2551, 19.8452, 1, null)
+        );
+        mockMvc.perform(
+                        put("/api/v1/rides/stop-ride")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(om.writeValueAsString(dto))
+                )
+                .andExpect(status().isBadRequest());
+    }
+    @Test
+    //if service throws bad request exception, endpoint should return status code 400
+    @DisplayName("Exception: Ride has no stops -> 400")
+    @WithMockUser(username = "driver@mail.com", roles = "DRIVER")
+    void stopRide_noStops_badRequest() throws Exception {
+        doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Ride has no stops"))
+                .when(rideService).stopRide(ArgumentMatchers.any(StopRideDTO.class));
+        mockMvc.perform(
+                        put("/api/v1/rides/stop-ride")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(om.writeValueAsString(validDto()))
+                )
+                .andExpect(status().isBadRequest());
+    }
+    @Test
+    //test if endpoint accepts empty request
+    @DisplayName("REST: missing body -> 400")
+    @WithMockUser(username = "driver@mail.com", roles = "DRIVER")
+    void stopRide_missingBody_badRequest() throws Exception {
+        mockMvc.perform(
+                        put("/api/v1/rides/stop-ride")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
This PR introduces REST integration tests for the stop ride functionality.

The goal is to validate the REST layer independently from the service and persistence layers, ensuring correct API behavior and security enforcement.
What was done:

- Added integration tests for PUT /api/v1/rides/stop-ride

- Used @SpringBootTest and @AutoConfigureMockMvc

- Mocked RideService using @MockitoBean to isolate REST layer

- Covered the following scenarios:

1. DRIVER successfully stops a ride
2. PASSENGER role is forbidden
3. Anonymous user is rejected 
4. Missing request body 
5. Service-layer exceptions correctly mapped to HTTP status codes
6. Verified controller–service interaction

Closes #94 