### PR TITLE
Fix: Refactor Driver History to Fragment & update menu UI

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -30,10 +30,6 @@
             android:name=".presentation.view.EditProfileActivity"
             android:exported="false" />
         <activity
-            android:name=".presentation.view.DriverHistoryActivity"
-            android:exported="false"
-            android:theme="@style/Theme.Mobile" />
-        <activity
             android:name=".presentation.view.RegisterActivity"
             android:exported="true"
             android:windowSoftInputMode="stateHidden|adjustResize" />

--- a/mobile/app/src/main/java/com/ftn/mobile/presentation/view/MainActivity.java
+++ b/mobile/app/src/main/java/com/ftn/mobile/presentation/view/MainActivity.java
@@ -12,9 +12,12 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
+import androidx.fragment.app.Fragment;
+
 import com.ftn.mobile.R;
 import com.ftn.mobile.data.local.TokenStorage;
 import com.ftn.mobile.data.local.UserRoleManger;
+import com.ftn.mobile.presentation.fragments.DriverHistoryFragment;
 import com.google.android.material.navigation.NavigationView;
 
 public class MainActivity extends AppCompatActivity {
@@ -50,6 +53,12 @@ public class MainActivity extends AppCompatActivity {
             if (profileItem != null) {
                 profileItem.setVisible(isLoggedIn);
             }
+
+            MenuItem historyItem = menu.findItem(R.id.nav_history);
+            if (historyItem != null) {
+                boolean isDriver = "ROLE_DRIVER".equals(role);
+                historyItem.setVisible(isDriver);
+            }
         });
 
         String token = TokenStorage.get(this);
@@ -73,8 +82,10 @@ public class MainActivity extends AppCompatActivity {
             int id = item.getItemId();
 
             if (id == R.id.nav_history) {
-                Intent intent = new Intent(MainActivity.this, DriverHistoryActivity.class);
-                startActivity(intent);
+                openFragment(new DriverHistoryFragment(), "Ride History");
+            } else if (id == R.id.nav_home) {
+                removeCurrentFragment();
+                getSupportActionBar().setTitle("SmartRide");
             } else if (id == R.id.nav_profile) {
                 Intent intent = new Intent(MainActivity.this, ProfileActivity.class);
                 startActivity(intent);
@@ -85,12 +96,26 @@ public class MainActivity extends AppCompatActivity {
                 Intent intent = new Intent(MainActivity.this, LoginActivity.class);
                 startActivity(intent);
             }
-            else if (id == R.id.nav_home) {
-                Intent intent = new Intent(MainActivity.this, MainActivity.class);
-                startActivity(intent);
-            }
             drawerLayout.closeDrawers();
             return true;
         });
+    }
+    private void openFragment(Fragment fragment, String title) {
+        getSupportFragmentManager().beginTransaction()
+                .replace(R.id.fragment_container, fragment)
+                .addToBackStack(null)
+                .commit();
+
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setTitle(title);
+        }
+    }
+
+    private void removeCurrentFragment() {
+        Fragment fragment = getSupportFragmentManager().findFragmentById(R.id.fragment_container);
+        if (fragment != null) {
+            getSupportFragmentManager().beginTransaction().remove(fragment).commit();
+            getSupportFragmentManager().popBackStack(null, androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE);
+        }
     }
 }

--- a/mobile/app/src/main/res/layout/activity_main.xml
+++ b/mobile/app/src/main/res/layout/activity_main.xml
@@ -19,24 +19,21 @@
             android:id="@+id/toolbar"
             android:layout_width="0dp"
             android:layout_height="?attr/actionBarSize"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="52dp"
             android:background="@color/primary"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:title="Uber App"
+            app:title="SmartRide"
             app:titleTextColor="@color/text" />
 
-        <TextView
-            android:id="@+id/temp_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            tools:text="..."
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/toolbar" />
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fragment_container"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/toolbar"
+            app:layout_constraintBottom_toBottomOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -44,6 +41,9 @@
         android:id="@+id/nav_view"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
+        android:background="@color/background"
+        app:itemTextColor="@color/text"
+        app:itemTextAppearance="@style/NavMenuTextStyle"
         android:layout_gravity="start"
         app:menu="@navigation/nav_menu" />
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/mobile/app/src/main/res/layout/fragment_driver_history.xml
+++ b/mobile/app/src/main/res/layout/fragment_driver_history.xml
@@ -19,15 +19,17 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/adhRecycleView"
-        android:layout_width="409dp"
-        android:layout_height="729dp"
+        android:layout_width="408dp"
+        android:layout_height="706dp"
         android:layout_marginStart="1dp"
         android:layout_marginTop="1dp"
         android:layout_marginEnd="1dp"
         android:layout_marginBottom="1dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.666"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btnFilterHistory"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/btnFilterHistory"/>
+        app:layout_constraintVertical_bias="0.971" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/mobile/app/src/main/res/values/styles.xml
+++ b/mobile/app/src/main/res/values/styles.xml
@@ -17,4 +17,7 @@
         <item name="android:windowMinWidthMajor">100%</item>
         <item name="android:windowMinWidthMinor">100%</item>
     </style>
+    <style name="NavMenuTextStyle">
+        <item name="android:textSize">18sp</item> <item name="android:textAllCaps">false</item>
+    </style>
 </resources>


### PR DESCRIPTION
This pull request refactors the driver ride history feature from an activity to a fragment and integrates it into the main activity's navigation flow. It also updates the main layout to support fragment navigation and improves UI consistency. The most important changes are grouped below:

### Refactoring Driver History to Fragment

* Converted `DriverHistoryActivity` into `DriverHistoryFragment`, moving the logic from an activity to a fragment and updating all related code to use fragment lifecycle methods and context handling. (`mobile/app/src/main/java/com/ftn/mobile/presentation/fragments/DriverHistoryFragment.java`, `mobile/app/src/main/AndroidManifest.xml`, 
* Renamed the layout file from `activity_driver_history.xml` to `fragment_driver_history.xml` and adjusted layout constraints for better integration. 

### Main Activity and Navigation Updates

* Updated `MainActivity` to display the driver history as a fragment instead of launching a separate activity, including new methods for fragment management and updating the navigation drawer to show/hide the history menu item based on user role. (`mobile/app/src/main/java/com/ftn/mobile/presentation/view/MainActivity.java`,
* Modified the main layout (`activity_main.xml`) to replace the placeholder `TextView` with a `FragmentContainerView` for fragment display and improved navigation drawer appearance. 
### UI and Style Improvements

* Added a custom style for navigation menu text and updated toolbar and navigation drawer appearance for better consistency. (`mobile/app/src/main/res/values/styles.xml`, `mobile/app/src/main/res/layout/activity_main.xml`, 


Closes: #99 