### PR TITLE
Feature: Admin rides history on server implemented

### DIFF
--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/controllers/rides/RideController.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/controllers/rides/RideController.java
@@ -11,14 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import rs.ac.uns.ftn.asd.ProjekatSIIT2025.dto.rides.*;
 import rs.ac.uns.ftn.asd.ProjekatSIIT2025.model.Ride;
@@ -103,6 +96,12 @@ public class RideController {
     @GetMapping(value = "/{id}/details", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PassengerRideDetailsResponseDTO> getRideDetails(@PathVariable Long id ){
         PassengerRideDetailsResponseDTO response = rideService.getRideDetails(id);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping(value = "/{id}/details/admin", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<AdminRideDetailsResponseDTO> getRideDetailsForAdmin(@PathVariable Long id){
+        AdminRideDetailsResponseDTO response = rideService.getRideDetailsForAdmin(id);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/dto/rides/AdminRideDetailsResponseDTO.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/dto/rides/AdminRideDetailsResponseDTO.java
@@ -1,0 +1,126 @@
+package rs.ac.uns.ftn.asd.ProjekatSIIT2025.dto.rides;
+
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.dto.users.PassengerInfoDTO;
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.model.RideStop;
+
+import java.util.List;
+import java.util.Map;
+
+public class AdminRideDetailsResponseDTO {
+    private Long rideId;
+    private List<RideStop> rideStops;
+    private double distanceKm;
+    private double totalPrice;
+    private String driverName;
+    private String driverLastName;
+    private String driverEmail;
+    private String driverPhoneNumber;
+    private Map<String, String> reportReasons; //passenger email and report reason
+    private List<RideGradeDTO> rideGrades;
+    private List<PassengerInfoDTO> passengersInfo;
+
+    public AdminRideDetailsResponseDTO() {
+    }
+
+    public AdminRideDetailsResponseDTO(Long rideId, List<RideStop> rideStops, double distanceKm, double totalPrice, String driverName, String driverLastName, String driverEmail, String driverPhoneNumber, Map<String, String> reportReasons, List<RideGradeDTO> rideGrades, List<PassengerInfoDTO> passengersInfo) {
+        this.rideId = rideId;
+        this.rideStops = rideStops;
+        this.distanceKm = distanceKm;
+        this.totalPrice = totalPrice;
+        this.driverName = driverName;
+        this.driverLastName = driverLastName;
+        this.driverEmail = driverEmail;
+        this.driverPhoneNumber = driverPhoneNumber;
+        this.reportReasons = reportReasons;
+        this.rideGrades = rideGrades;
+        this.passengersInfo = passengersInfo;
+    }
+
+    public Long getRideId() {
+        return rideId;
+    }
+
+    public void setRideId(Long rideId) {
+        this.rideId = rideId;
+    }
+
+    public List<RideStop> getRideStops() {
+        return rideStops;
+    }
+
+    public void setRideStops(List<RideStop> rideStops) {
+        this.rideStops = rideStops;
+    }
+
+    public double getDistanceKm() {
+        return distanceKm;
+    }
+
+    public void setDistanceKm(double distanceKm) {
+        this.distanceKm = distanceKm;
+    }
+
+    public double getTotalPrice() {
+        return totalPrice;
+    }
+
+    public void setTotalPrice(double totalPrice) {
+        this.totalPrice = totalPrice;
+    }
+
+    public String getDriverName() {
+        return driverName;
+    }
+
+    public void setDriverName(String driverName) {
+        this.driverName = driverName;
+    }
+
+    public String getDriverLastName() {
+        return driverLastName;
+    }
+
+    public void setDriverLastName(String driverLastName) {
+        this.driverLastName = driverLastName;
+    }
+
+    public String getDriverEmail() {
+        return driverEmail;
+    }
+
+    public void setDriverEmail(String driverEmail) {
+        this.driverEmail = driverEmail;
+    }
+
+    public String getDriverPhoneNumber() {
+        return driverPhoneNumber;
+    }
+
+    public void setDriverPhoneNumber(String driverPhoneNumber) {
+        this.driverPhoneNumber = driverPhoneNumber;
+    }
+
+    public Map<String, String> getReportReasons() {
+        return reportReasons;
+    }
+
+    public void setReportReasons(Map<String, String> reportReasons) {
+        this.reportReasons = reportReasons;
+    }
+
+    public List<RideGradeDTO> getRideGrades() {
+        return rideGrades;
+    }
+
+    public void setRideGrades(List<RideGradeDTO> rideGrades) {
+        this.rideGrades = rideGrades;
+    }
+
+    public List<PassengerInfoDTO> getPassengersInfo() {
+        return passengersInfo;
+    }
+
+    public void setPassengersInfo(List<PassengerInfoDTO> passengersInfo) {
+        this.passengersInfo = passengersInfo;
+    }
+}

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/dto/rides/AdminRideHistoryResponseDTO.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/dto/rides/AdminRideHistoryResponseDTO.java
@@ -1,0 +1,105 @@
+package rs.ac.uns.ftn.asd.ProjekatSIIT2025.dto.rides;
+
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.model.RideCancellation;
+import rs.ac.uns.ftn.asd.ProjekatSIIT2025.model.RideStop;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class AdminRideHistoryResponseDTO {
+    private Long rideId;
+    private List<RideStop> rideStops;
+    private LocalDateTime startedAt;
+    private LocalDateTime finishedAt;
+    private LocalDateTime createdAt;
+    private double totalPrice;
+    private String userWhoCancelled;
+    private boolean isCancelled;
+    private boolean panic;
+
+    public AdminRideHistoryResponseDTO(LocalDateTime finishedAt, LocalDateTime startedAt, LocalDateTime createdAt,
+                                       List<RideStop> stops, Long id, double totalPrice, boolean panic,
+                                       String userWhoCancelled, boolean isCancelled) {
+        this.finishedAt = finishedAt;
+        this.startedAt = startedAt;
+        this.createdAt = createdAt;
+        this.rideStops = stops;
+        this.rideId = id;
+        this.totalPrice = totalPrice;
+        this.panic = panic;
+        this.userWhoCancelled = userWhoCancelled;
+        this.isCancelled = isCancelled;
+    }
+
+    public Long getRideId() {
+        return rideId;
+    }
+
+    public void setRideId(Long rideId) {
+        this.rideId = rideId;
+    }
+
+    public List<RideStop> getRideStops() {
+        return rideStops;
+    }
+
+    public void setRideStops(List<RideStop> rideStops) {
+        this.rideStops = rideStops;
+    }
+
+    public LocalDateTime getStartedAt() {
+        return startedAt;
+    }
+
+    public void setStartedAt(LocalDateTime startedAt) {
+        this.startedAt = startedAt;
+    }
+
+    public LocalDateTime getFinishedAt() {
+        return finishedAt;
+    }
+
+    public void setFinishedAt(LocalDateTime finishedAt) {
+        this.finishedAt = finishedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public double getTotalPrice() {
+        return totalPrice;
+    }
+
+    public void setTotalPrice(double totalPrice) {
+        this.totalPrice = totalPrice;
+    }
+
+    public String getUserWhoCancelled() {
+        return userWhoCancelled;
+    }
+
+    public void setUserWhoCancelled(String userWhoCancelled) {
+        this.userWhoCancelled = userWhoCancelled;
+    }
+
+    public boolean isCancelled() {
+        return isCancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        isCancelled = cancelled;
+    }
+
+    public boolean getPanic() {
+        return panic;
+    }
+
+    public void setPanic(boolean panic) {
+        this.panic = panic;
+    }
+}

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/dto/users/PassengerInfoDTO.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/dto/users/PassengerInfoDTO.java
@@ -1,0 +1,37 @@
+package rs.ac.uns.ftn.asd.ProjekatSIIT2025.dto.users;
+
+public class PassengerInfoDTO {
+    private String name;
+    private String lastName;
+    private String email;
+
+    public PassengerInfoDTO(String name, String lastName, String email) {
+        this.name = name;
+        this.lastName = lastName;
+        this.email = email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/model/Ride.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/model/Ride.java
@@ -87,7 +87,7 @@ public class Ride {
         this.passengers = passengers;
     }
 
-    public boolean isPanic() {
+    public boolean getIsPanic() {
         return panic;
     }
 

--- a/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/repositories/RideRepository.java
+++ b/server/ProjekatSIIT2025/src/main/java/rs/ac/uns/ftn/asd/ProjekatSIIT2025/repositories/RideRepository.java
@@ -30,6 +30,11 @@ public interface RideRepository extends JpaRepository<Ride, Long> {
     List<Ride> findByPassengers_IdAndStatusInAndCreatedAtBetween(Long id, List<RideStatus> statuses, Sort sort, LocalDateTime from, LocalDateTime to);
     List<Ride> findByPassengers_IdAndStatusInAndCreatedAtBefore(Long id, List<RideStatus> statuses, Sort sort, LocalDateTime to);
     List<Ride> findByPassengers_IdAndStatusInAndCreatedAtAfter(Long id, List<RideStatus> statuses, Sort sort, LocalDateTime from);
+
+    List<Ride> findByDriverIdAndStatusInAndCreatedAtBetween(Long id,List<RideStatus> statuses,Sort sort,LocalDateTime from, LocalDateTime to);
+    List<Ride> findByDriverIdAndStatusInAndCreatedAtBefore(Long id,List<RideStatus> statuses,Sort sort,LocalDateTime to);
+    List<Ride> findByDriverIdAndStatusInAndCreatedAtAfter(Long id,List<RideStatus> statuses,Sort sort,LocalDateTime from);
+    List<Ride> findByDriverIdAndStatusIn(Long id,List<RideStatus> statuses, Sort sort);
     @Query("SELECT r FROM Ride r WHERE " +
            "(:name IS NULL OR :name = '' OR " +
            " LOWER(r.driver.name) LIKE LOWER(CONCAT('%', :name, '%')) OR " +


### PR DESCRIPTION
Admin ride history endpoint with sorting and details view

Pull Request description

This PR introduces admin ride history functionality on server side.

Changes included:

    Added endpoint for retrieving passenger or driver ride history for admin page 

    Implemented sorting by multiple ride fields with validation

    Added optional filtering by ride creation date (createdAt)

    Implemented detailed ride view endpoint (route, driver info,passengers info, reports, reviews)

    Added DTOs for history list and detailed ride response

    Ensured access is restricted to authenticated admin

    Improved repository queries for driver-based ride lookup

Notes:
Sorting is handled on the backend to ensure consistent results.
Filtering is based on ride creation time, as required by specification.
Detailed data is loaded only when explicitly requested to keep history endpoint lightweight.

Closes #123 