### PR TITLE
Fix: Restore Api Provider

### DIFF
--- a/mobile/app/src/main/java/com/ftn/mobile/data/remote/ApiProvider.java
+++ b/mobile/app/src/main/java/com/ftn/mobile/data/remote/ApiProvider.java
@@ -5,6 +5,8 @@ import com.ftn.mobile.data.remote.api.AuthApi;
 
 import com.ftn.mobile.data.remote.api.DriverApi;
 import com.ftn.mobile.data.remote.api.ForgotPasswordApi;
+import com.ftn.mobile.data.remote.api.PriceApi;
+import com.ftn.mobile.data.remote.api.RideApi;
 import com.ftn.mobile.data.remote.api.UserApi;
 
 public final class ApiProvider {
@@ -18,6 +20,10 @@ public final class ApiProvider {
     private static DriverApi driverApi;
 
     private static AdminApi adminApi;
+
+    private static PriceApi priceApi;
+
+    private static RideApi rideApi;
 
     private ApiProvider() {}
 
@@ -53,6 +59,20 @@ public final class ApiProvider {
             adminApi = RetrofitClient.getRetrofit().create(AdminApi.class);
         }
         return adminApi;
+    }
+
+    public static PriceApi price() {
+        if (priceApi == null){
+            priceApi = RetrofitClient.getRetrofit().create(PriceApi.class);
+        }
+        return priceApi;
+    }
+
+    public static RideApi ride() {
+        if (rideApi == null){
+            rideApi = RetrofitClient.getRetrofit().create(RideApi.class);
+        }
+        return rideApi;
     }
 }
 


### PR DESCRIPTION
This PR restores the RideApi and PriceApi instances in ApiProvider.java. These were accidentally removed during a previous merge, which caused NullPointerException crashes in fragments that depend on these services.

Changes:

- Re-implemented ride() method in ApiProvider.
- Added price() method in ApiProvider to support price calculation features.
- Fixed broken references in fragments that were unable to access these APIs.