### PR TITLE
Fix: map requests

### DIFF
--- a/frontend/src/app/shared/components/map/map.service.ts
+++ b/frontend/src/app/shared/components/map/map.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable,map } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { environment } from '../../../../env/environment';
 import { RideTrackingDTO } from '../../models/ride.model';
 
@@ -10,25 +10,54 @@ export type RouteInfo = { distanceKm: number; estimatedTime: number };
 })
 //todo : make interface/class in shared folder to handle specific data from API, DONT use any data type
 export class MapService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient) { }
 
-  search(street: string): Observable<any> {
+  /*search(street: string): Observable<any> {
     //for given street, returns list of coordinates that match that street
     return this.http.get('https://nominatim.openstreetmap.org/search?format=json&q=' + street);
+  }*/
+
+  search(street: string): Observable<any> {
+    const token = 'pk.eyJ1IjoidG90YWxseS1zcGllczMzIiwiYSI6ImNtanpxYm54dzV1MTEzZnF4M3c4ejZ0c28ifQ.iwa5IGW8kqTBZtwXvVTQcQ';
+
+    const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(street)}.json?access_token=${token}`;
+
+    return this.http.get(url).pipe(
+      map((res: any) => {
+        return res.features.map((f: any) => ({
+          lat: f.center[1],
+          lon: f.center[0],
+          display_name: f.place_name
+        }));
+      })
+    );
   }
 
   reverseSearch(lat: number, lon: number): Observable<any> {
     //for given coordinates, returns list of streets
-    return this.http.get(
-      `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}&<params>`
+    const token = 'pk.eyJ1IjoidG90YWxseS1zcGllczMzIiwiYSI6ImNtanpxYm54dzV1MTEzZnF4M3c4ejZ0c28ifQ.iwa5IGW8kqTBZtwXvVTQcQ';
+
+    const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${lon},${lat}.json?access_token=${token}`;
+
+    return this.http.get(url).pipe(
+      map((res: any) => {
+        return {
+          display_name: res.features[0]?.place_name || 'Unknown location'
+        };
+      })
     );
+
+    /*return this.http.get(
+      `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}&<params>`
+    );*/
   }
+
 
   getAllVehiclePositions(): Observable<any[]> {
     return this.http.get<any[]>(`${environment.apiHost}/vehicles/active`, {
       headers: new HttpHeaders({ 'skip': 'true' })
     }); // skip because we dont need token
-  } 
+  }
 
   getRouteInfo(fromLat: number, fromLng: number, toLat: number, toLng: number): Observable<RouteInfo> {
     const token =


### PR DESCRIPTION
This PR replaces Nominatim (OpenStreetMap) with Mapbox Geocoding API for all address-to-coordinate (forward geocoding) and coordinate-to-address (reverse geocoding) lookups.

**Problem**

- CORS Issues: Nominatim's usage policy blocks direct requests from localhost in the browser, causing Access-Control-Allow-Origin errors.
- Rate Limiting: Nominatim strictly limits requests to 1 per second. Our forkJoin logic for multiple stops often triggered 403/429 errors.
- Inconsistency: The application was already using Mapbox for routing but relying on Nominatim for geocoding, leading to mixed provider dependencies.